### PR TITLE
Add ``?next`` command for stage queries

### DIFF
--- a/models.py
+++ b/models.py
@@ -1,0 +1,22 @@
+import enum
+from dataclasses import dataclass, field
+from typing import Any, Self
+
+
+class QueryType(enum.StrEnum):
+    ANY = enum.auto()
+    STAGE = enum.auto()
+
+    @classmethod
+    def _missing_(cls, value: object) -> Self:
+        if isinstance(value, str):
+            if value in dir(cls):
+                return cls[value]
+        return cls["ANY"]
+
+
+@dataclass
+class UserQuery:
+    type: QueryType
+    args: tuple[Any, ...] = field(default_factory=tuple)
+    kwargs: dict[str, Any] = field(default_factory=dict)

--- a/tables/commands.txt
+++ b/tables/commands.txt
@@ -73,3 +73,4 @@ explain	sobble_calc_functions	explain	prefix	1
 e	sobble_calc_functions	explain	prefix	1
 submitcompscore	shuffle_commands	submit_comp_score	prefix	3
 compscores	shuffle_commands	comp_scores	prefix	3
+next	shuffle_commands	next_stage	prefix	1

--- a/tables/settings.txt
+++ b/tables/settings.txt
@@ -166,3 +166,5 @@ reminders_table	shuffle_tables/reminders
 user_cooldown_1	1000	
 comp_scores_table	shuffle_tables/comp_scores	
 current_comp_score_id	5	3
+message_last_query_not_stage	Your previous query was not a main or EX stage
+message_last_query_error	Unexpected error, contact my owner to investigate


### PR DESCRIPTION
Only work on main/EX stages, including when the stage is selected via prompt (e.g. multiple stages with the same pokemon name)
Match previous kwargs, e.g. if user requests ``?stage`` with ``startingboard=True``, ``?next`` also uses ``startingboard=True``
Return an error message if the previous command didn't return a stage message (including e.g. when a stage selection is canceled)

Require to store user query history (same length limit as bot replies history)

