### PR TITLE
Allow ``?pokemon`` to display the pokemon of the previous query if it's a stage

### DIFF
--- a/tables/settings.txt
+++ b/tables/settings.txt
@@ -168,3 +168,4 @@ comp_scores_table	shuffle_tables/comp_scores
 current_comp_score_id	5	3
 message_last_query_not_stage	Your previous query was not a main or EX stage
 message_last_query_error	Unexpected error, contact my owner to investigate
+message_pokemon_last_query_not_stage	Your previous query was not a (valid) stage


### PR DESCRIPTION
Used by calling ``?pokemon`` (or its aliases) with no arguments.

Once a stage is retrieved, save the pokemon name in the user's query history entry (adding a kwarg to avoid messing with ``?next``) to avoid having to query the stage table.

Querying an eb stage is registered as querying its special stage