### PR TITLE
Make ``?next`` and ``?pokemon`` (no args) use the latest queried stage

### DIFF
--- a/shuffle_commands.py
+++ b/shuffle_commands.py
@@ -304,19 +304,21 @@ async def next_stage(
             content=settings.message_last_query_error,
         )
 
+    kwargs = query_.kwargs | kwargs
+
     last_stage_id = query_.args[0]
-    if last_stage_id.startswith("s"):
+    if last_stage_id.startswith("s") and last_stage_id[1:].isdigit():
         return await context.koduck.send_message(
             receive_message=context.message,
             content=settings.message_last_query_invalid_stage,
         )
-    if last_stage_id.startswith("ex"):
-        return await stage(context, f"ex{int(last_stage_id[2:]) + 1}", **query_.kwargs)
+    if last_stage_id.startswith("ex") and last_stage_id[2:].isdigit():
+        return await stage(context, f"ex{int(last_stage_id[2:]) + 1}", **kwargs)
     if last_stage_id.isdigit():
         next_id = int(last_stage_id) + 1
         if next_id == 701:
             next_id = 1
-        return await stage(context, str(next_id), **query_.kwargs)
+        return await stage(context, str(next_id), **kwargs)
 
     return await context.koduck.send_message(
             receive_message=context.message,

--- a/shuffle_commands.py
+++ b/shuffle_commands.py
@@ -126,12 +126,16 @@ async def last_stage_pokemon(context: KoduckContext) -> discord.Message | None:
     user_id = context.message.author.id
     query_history = context.koduck.query_history[user_id]
     if len(query_history) < 2 or query_history[-2].type != QueryType.STAGE:
-        return await context.send_message(
+        return await context.koduck.send_message(
+            receive_message=context.message,
             content=settings.message_pokemon_last_query_not_stage
         )
     query_ = query_history[-2]
     if not (query_.args and "pokemon" in query_.kwargs):
-        return await context.send_message(content=settings.message_last_query_error)
+        return await context.koduck.send_message(
+            receive_message=context.message,
+            content=settings.message_last_query_error
+        )
     last_stage_pokemon = query_.kwargs['pokemon']
     return await pokemon(context, last_stage_pokemon)
 

--- a/tables/commands.txt
+++ b/tables/commands.txt
@@ -74,4 +74,4 @@ e	sobble_calc_functions	explain	prefix	1
 submitcompscore	shuffle_commands	submit_comp_score	prefix	3
 compscores	shuffle_commands	comp_scores	prefix	3
 next	shuffle_commands	next_stage	prefix	1
-nextx	shuffle_commands	next_stage_shorthand	1
+nextx	shuffle_commands	next_stage_shorthand	prefix	1

--- a/tables/settings.txt
+++ b/tables/settings.txt
@@ -166,6 +166,6 @@ reminders_table	shuffle_tables/reminders
 user_cooldown_1	1000	
 comp_scores_table	shuffle_tables/comp_scores	
 current_comp_score_id	5	3
-message_last_query_not_stage	Your previous query was not a main or EX stage
+message_last_query_invalid_stage	The command only works with a main or EX stage
 message_last_query_error	Unexpected error, contact my owner to investigate
-message_pokemon_last_query_not_stage	Your previous query was not a (valid) stage
+message_no_previous_stage	No stage in your recent query history


### PR DESCRIPTION
Search the latest queried stage in the user history instead of just looking at the latest query.

Fix an issue with the previous update that would raise an exception when using ``?pokemon`` (or ``?p``) without a query history, instead of sending an error message.

Fix #12 by passing a correctly updated dictionary of options.