### PR TITLE
Case insensitive check when choosing a lookup result

### DIFF
--- a/shuffle_commands.py
+++ b/shuffle_commands.py
@@ -1254,7 +1254,11 @@ async def pokemon_lookup(context, query=None, enable_dym=True, skill_lookup=Fals
         if result is None:
             return
         else:
-            return choices[result][1]
+            choice = choices[result][1]
+            if skill_lookup:
+                return skill_dict.get(choice.lower(), choice)
+            else:
+                return pokemon_dict.get(choice.lower(), choice)
     
     else:
         return query


### PR DESCRIPTION
Fix #9 

#### Cause of the behaviour

The lookup function does a case insensitive check against the database as the first step.
If it does not find a result, it looks for close matches (both for names and aliases), and prompts the user to make a choice between plausible results.
The user's pick is then _not_ checked again, so if the alias is not correctly spelled to match the database entry, it fails unexpectedly.

#### Suggested fix

After an user choice is made, do the same check done at the beginning, this time against the user's choice.